### PR TITLE
Update license notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ Apart from that, XSStrike has crawling, fuzzing, parameter discovery, WAF detect
 ### Contribution & License
 Useful issues and pull requests are appreciated.
 
-I haven't decided a license yet.
+Licensed under the GNU GPLv3, see [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
**Note:** as per the page [How to use GNU licenses for your own software](https://www.gnu.org/licenses/gpl-howto.html), it would be a good idea to use the full notice with the name of the copyright holder instead. It should also state whether the software is licensed under GPLv3 or later (recommended for compatibility reasons) or GPLv3 only.