### PR TITLE
Fortiweb update

### DIFF
--- a/db/wafSignatures.json
+++ b/db/wafSignatures.json
@@ -132,7 +132,7 @@
 	"FortiWeb Web Application Firewall (Fortinet)" : {
 		"code" : "",
 		"page" : "\\.fgd_icon|\\.blocked|\\.authenticate",
-		"headers" : "FORTIWAFSID="
+		"headers" : "FORTIWAFSID=|cookiesession1="
 	},
 	"Hyperguard Web Application Firewall (art of defence)" : {
 		"code" : "",


### PR DESCRIPTION
Hi,

New versions of Fortiweb use 'cookiesession1' as cookie name.