### PR TITLE
Add commandline argument --headers-from-file 

### DIFF
--- a/headers.txt
+++ b/headers.txt
@@ -1,0 +1,2 @@
+Cookies: hello
+

--- a/headers.txt
+++ b/headers.txt
@@ -1,2 +1,0 @@
-Cookies: hello
-

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -61,9 +61,9 @@ parser.add_argument(
 parser.add_argument('-l', '--level', help='level of crawling',
                     dest='level', type=int, default=2)
 parser.add_argument('--headers', help='add headers',
-                    dest='add_headers', action='store_true')
-parser.add_argument('--headers-from-file', help='read headers from text file',
                     dest='add_headers', nargs='?', const=True)
+parser.add_argument('--headers-from-file', help='read headers from text file',
+					dest='file_headers', action='store')
 parser.add_argument('-t', '--threads', help='number of threads',
                     dest='threadCount', type=int, default=core.config.threadCount)
 parser.add_argument('-d', '--delay', help='delay between requests',

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -62,6 +62,8 @@ parser.add_argument('-l', '--level', help='level of crawling',
                     dest='level', type=int, default=2)
 parser.add_argument('--headers', help='add headers',
                     dest='add_headers', action='store_true')
+parser.add_argument('--headers-from-file', help='read headers from text file',
+					dest='file_headers', action='store')
 parser.add_argument('-t', '--threads', help='number of threads',
                     dest='threadCount', type=int, default=core.config.threadCount)
 parser.add_argument('-d', '--delay', help='delay between requests',
@@ -76,10 +78,17 @@ parser.add_argument('--blind', help='inject blind XSS payload while crawling',
                     dest='blindXSS', action='store_true')
 args = parser.parse_args()
 
-if args.add_headers:
-    headers = extractHeaders(prompt())
+if args.file_headers:
+	with open(args.file_headers, "r") as f:
+		user_headers = extractHeaders(f.read())
+		from core.config import headers
+		for key in user_headers:
+			headers[key] = user_headers[key]
 else:
-    from core.config import headers
+	if args.add_headers:
+		headers = extractHeaders(prompt())
+	else:
+		from core.config import headers
 
 # Pull all parameter values of dict from argparse namespace into local variables of name == key
 # The following works, but the static checkers are too static ;-) locals().update(vars(args))


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
Add commandline argument --headers-from-file which lets users specify headers from text file; user specified headers will be appended to/replace the pre-existing headers in core.config.headers

#### Where has this been tested?
Python Version: Python 3.6.6
Operating System: Ubuntu 18.04

#### Does this close any currently open issues? 

#### Does this add any new dependency?

#### Does this add any new command line switch/option?
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->
--headers-from-file

#### Any other comments you would like to make?

#### Some Questions
- [ ] I have documented my code.
- [x] I have tested my build before submitting the pull request.
