### PR TITLE
Some improvments and error handling to the `--headers` argument

### DIFF
--- a/core/prompt.py
+++ b/core/prompt.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 
 from core.config import defaultEditor
+from core.colors import info, white, bad, yellow
+
 
 
 def prompt(default=None):
@@ -14,10 +16,16 @@ def prompt(default=None):
             tmpfile.flush()
         child_pid = os.fork()
         is_child = child_pid == 0
-
         if is_child:
             # opens the file in the editor
-            os.execvp(editor, [editor, tmpfile.name])
+            try:
+                os.execvp(editor, [editor, tmpfile.name])
+            except FileNotFoundError:
+                print('%s You don\'t have either a default $EDITOR \
+value defined nor \'nano\' text editor' % bad)
+                print('%s Execute %s`export EDITOR=/pat/to/your/editor` \
+%sthen run XSStrike again.\n\n' % (info, yellow,white))
+                exit(1)
         else:
             os.waitpid(child_pid, 0)  # wait till the editor gets closed
             tmpfile.seek(0)

--- a/core/utils.py
+++ b/core/utils.py
@@ -79,6 +79,7 @@ def stripper(string, substring, direction='right'):
 
 
 def extractHeaders(headers):
+    headers = headers.replace('\\n', '\n')
     sorted_headers = {}
     matches = re.findall(r'(.*):\s(.*)', headers)
     for match in matches:

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -61,7 +61,7 @@ parser.add_argument(
 parser.add_argument('-l', '--level', help='level of crawling',
                     dest='level', type=int, default=2)
 parser.add_argument('--headers', help='add headers',
-                    dest='add_headers', action='store_true')
+                    dest='add_headers', nargs='?', const=True)
 parser.add_argument('-t', '--threads', help='number of threads',
                     dest='threadCount', type=int, default=core.config.threadCount)
 parser.add_argument('-d', '--delay', help='delay between requests',
@@ -76,8 +76,10 @@ parser.add_argument('--blind', help='inject blind XSS payload while crawling',
                     dest='blindXSS', action='store_true')
 args = parser.parse_args()
 
-if args.add_headers:
+if type(args.add_headers) == bool:
     headers = extractHeaders(prompt())
+elif type(args.add_headers) == str:
+    headers = extractHeaders(args.add_headers)
 else:
     from core.config import headers
 


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.

1. Ability to add request headers directly from command line without any need to open any external text editor. Noting that If `--headers` has an argument it will take it. If not, it will try to open an external editor.
`$ python xsstrike.py -u "http://example.com/search.php" --heades "Accept-Language: en"`




2. Handle the case when --headers argument is passed to open an external text editor with the `$EDITOR` value being defined nor `nano` text editor being installed.

#### Where has this been tested?
Python Version: 3.7.1
Operating System: Arch Linux

#### Does this close any currently open issues? 
No.
#### Does this add any new dependency?
No.
#### Does this add any new command line switch/option?
It improved an existing one.
