### PR TITLE
FIX: FoundParams not being checked for in reflected response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#vscode
+.vscode/

--- a/core/arjun.py
+++ b/core/arjun.py
@@ -28,8 +28,7 @@ def arjun(url, GET, headers, delay, timeout):
             continue
         print('%s Heuristics found a potentially valid parameter: %s%s%s. Priortizing it.' % (
             good, green, foundParam, end))
-        if foundParam in blindParams:
-            blindParams.remove(foundParam)
+        if foundParam not in blindParams:
             blindParams.insert(0, foundParam)
     threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=threadCount)
     futures = (threadpool.submit(checky, param, paraNames, url,


### PR DESCRIPTION
Fixed issue where foundParams are not being checked for in reflected in response; added vscode folder to gitignore

Tested with: python3 xsstrike.py --params -u http://brutelogic.com.br/xss.php
Before fix: params b1, b2, b3, b4 are detected but not found as valid, no payload is generated
After fix: params b1, b2, b3, b4 are detected and found as valid, payload is generated
#### Some Questions
- [x ] I have documented my code.
- [x ] I have tested my build before submitting the pull request.
