### PR TITLE
Enable Colors for Windows 10 Build >= 10586

### DIFF
--- a/core/colors.py
+++ b/core/colors.py
@@ -1,9 +1,15 @@
 import sys
+import os
+import platform
 
 colors = True  # Output should be colored
 machine = sys.platform  # Detecting the os of current system
+checkplatform = platform.platform() # Get current version of OS
 if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
     colors = False  # Colors shouldn't be displayed in mac & windows
+if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[2]) >= 10586:
+    colors = True
+    os.system('')   # Enables the ANSI
 if not colors:
     end = red = white = green = yellow = run = bad = good = info = que = ''
 else:


### PR DESCRIPTION
Windows 10 added support for ANSI colors since Build 10586.
From Build 14393 ANSI needs to enabled by executable, hence os.system('') is used

Source : 
https://stackoverflow.com/a/39675059
https://github.com/symfony/symfony/issues/17499

#### What does it implement/fix? Explain your changes.
ANSI Colors for Windows 10

#### Where has this been tested?
Python Version:\ 3.6.7
Operating System: Windows-10-10.0.17763-SP0
![colors](https://user-images.githubusercontent.com/38807205/52176490-8c7e8880-27d9-11e9-8aa0-619eab8d89aa.jpg)
