### PR TITLE
add cookies support

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,8 @@ xsschecker = 'v3dm0s'  # A non malicious string to check for reflections and stu
 #  More information on adding proxies: http://docs.python-requests.org/en/master/user/advanced/#proxies
 proxies = {'http': 'http://0.0.0.0:8080', 'https': 'http://0.0.0.0:8080'}
 
+cookies = ''
+
 minEfficiency = 90  # payloads below this efficiency will not be displayed
 
 delay = 0  # default delay between http requests

--- a/core/requester.py
+++ b/core/requester.py
@@ -35,13 +35,13 @@ def requester(url, data, headers, GET, delay, timeout):
     logger.debug_json('Requester headers:', headers)
     try:
         if GET:
-            response = requests.get(url, params=data, headers=headers,
+            response = requests.get(url, params=data, headers=headers, cookies=core.config.cookies,
                                     timeout=timeout, verify=False, proxies=core.config.proxies)
         elif core.config.globalVariables['jsonData']:
-            response = requests.get(url, json=data, headers=headers,
+            response = requests.get(url, json=data, headers=headers, cookies=core.config.cookies,
                                     timeout=timeout, verify=False, proxies=core.config.proxies)
         else:
-            response = requests.post(url, data=data, headers=headers,
+            response = requests.post(url, data=data, headers=headers, cookies=core.config.cookies,
                                      timeout=timeout, verify=False, proxies=core.config.proxies)
         return response
     except ProtocolError:

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -60,6 +60,8 @@ parser.add_argument('-l', '--level', help='level of crawling',
                     dest='level', type=int, default=2)
 parser.add_argument('--headers', help='add headers',
                     dest='add_headers', nargs='?', const=True)
+parser.add_argument('--cookies', help='add cookies',
+                    dest='add_cookies', nargs='?', const=True)
 parser.add_argument('-t', '--threads', help='number of threads',
                     dest='threadCount', type=int, default=core.config.threadCount)
 parser.add_argument('-d', '--delay', help='delay between requests',
@@ -96,6 +98,7 @@ args_file = args.args_file
 args_seeds = args.args_seeds
 level = args.level
 add_headers = args.add_headers
+add_cookies = args.add_cookies
 threadCount = args.threadCount
 delay = args.delay
 skip = args.skip
@@ -128,6 +131,9 @@ elif type(args.add_headers) == str:
     headers = extractHeaders(args.add_headers)
 else:
     from core.config import headers
+
+if args.add_cookies:
+    core.config.cookies = converter(add_cookies)
 
 if path:
     paramData = converter(target, target)


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.

This implement cookies support. Because usually need to check XSS in the resources that are available only after sign in.

Cookies are specified in json format:
```bash
    xsstrike.py --cookies='{"a":1, "b":"2"}' ...
```

#### Where has this been tested?
Python Version: 3.6.8
Operating System: Linux

#### Does this close any currently open issues? 

no

#### Does this add any new dependency?

no

#### Does this add any new command line switch/option?

--cookies

#### Any other comments you would like to make?

The format of the arguments options (headers and cookies) would be nice to reflect that somewhere in the documentation.

#### Some Questions
- [ ] I have documented my code.
- [x] I have tested my build before submitting the pull request.
