### PR TITLE
fix html comment regex error

### DIFF
--- a/core/htmlParser.py
+++ b/core/htmlParser.py
@@ -61,7 +61,7 @@ def htmlParser(response, encoding):
                 environment_details[thisPosition] = {}
                 environment_details[thisPosition]['details'] = {}
     if len(position_and_context) < reflections:
-        comment_context = re.finditer(r'<!--(?![.\s\S]*-->)[.\s\S]*(%s)[.\s\S]*?-->' % xsschecker, response)
+        comment_context = re.finditer(r'<!--[\s\S]*?(%s)[\s\S]*?-->' % xsschecker, response)
         for occurence in comment_context:
             thisPosition = occurence.start(1)
             position_and_context[thisPosition] = 'comment'


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.

old regex can't match any html comment context.

```python
'<!--(?![.\s\S]*-->)[.\s\S]*(v3dm0s)[.\s\S]*?-->' 	#old

'<!--[\s\S]*?(%s)[\s\S]*?-->' 	# new
```

i write a simple  example here https://trinket.io/python/0cc57f3d1d

also you can check with 

```shell
python xsstrike.py -u "https://public-firing-range.appspot.com/reflected/parameter/body_comment?q=xss"
```

#### Where has this been tested?

Python Version:\ Python 3.7.4
Operating System: macOS

#### Does this close any currently open issues? 

no

#### Does this add any new dependency?

no

#### Does this add any new command line switch/option?
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->

#### Any other comments you would like to make?

no.

#### Some Questions
- [ ] I have documented my code.
- [x] I have tested my build before submitting the pull request.