### PR TITLE
Fix DOM scanner on Windows/macOS/iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.5
+- Fix color bug that resulted in DOM XSS vulnerabilities not
+  being reported on certain systems (Windows, macOS, iOS)
+
 ### 3.1.4
 - Negligible DOM XSS false positives
 - x10 Faster crawling by

--- a/core/colors.py
+++ b/core/colors.py
@@ -6,7 +6,7 @@ colors = True  # Output should be colored
 machine = sys.platform  # Detecting the os of current system
 checkplatform = platform.platform() # Get current version of OS
 if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
-    colors = False  # Colors shouldn't be displayed in mac & windows
+    colors = False  # Colors shouldn't be displayed on mac & windows
 if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[2]) >= 10586:
     colors = True
     os.system('')   # Enables the ANSI

--- a/core/dom.py
+++ b/core/dom.py
@@ -1,7 +1,9 @@
 import re
 
-from core.colors import red, end, yellow
+from core.colors import end, red, yellow
 
+if len(end) < 1:
+    end = red = yellow = '*'
 
 def dom(response):
     highlighted = []

--- a/core/updater.py
+++ b/core/updater.py
@@ -3,7 +3,7 @@ import re
 from requests import get
 
 from core.config import changes
-from core.colors import run, que, good, info, end, green
+from core.colors import que, info, end, green
 from core.log import setup_logger
 
 logger = setup_logger(__name__)

--- a/modes/crawl.py
+++ b/modes/crawl.py
@@ -2,7 +2,7 @@ import copy
 import re
 
 import core.config
-from core.colors import red, good, green, end
+from core.colors import green, end
 from core.config import xsschecker
 from core.filterChecker import filterChecker
 from core.generator import generator

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, quote, unquote
 
 from core.arjun import arjun
 from core.checker import checker
-from core.colors import good, bad, end, info, green, red, que
+from core.colors import end, green, que
 import core.config
 from core.config import xsschecker, minEfficiency
 from core.dom import dom


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.

The DOM scanner colors sources and sinks in script lines.  Moreover,
that scanner collects all colored lines:
https://github.com/s0md3v/XSStrike/blob/0ecedc1bba149931e3b32e53422d5b7c089ba9dc/core/dom.py#L50

As coloring is disabled on Windows, macOS, and iOS, no potentially
tainted lines will be collected on these platforms:
https://github.com/s0md3v/XSStrike/blob/0ecedc1bba149931e3b32e53422d5b7c089ba9dc/core/colors.py#L8-L9
Consequently, the report of potential DOM vulnerabilities is always
empty.

This change fixes this bug by surrounding sources and sinks with `*`
characters.

Also, this change removes unused colors imports.

#### Where has this been tested?

Python Version: 3.7.5
Operating System: macOS

#### Does this close any currently open issues? 

No

#### Does this add any new dependency?

No

#### Does this add any new command line switch/option?

No

#### Any other comments you would like to make?

No

#### Some Questions

- [X] I have documented my code.
- [X] I have tested my build before submitting the pull request.