### PR TITLE
Faf0/params as sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.5
+- Fix color bug that resulted in DOM XSS vulnerabilities not
+  being reported on certain systems (Windows, macOS, iOS)
+
 ### 3.1.4
 - Negligible DOM XSS false positives
 - x10 Faster crawling by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.6
+- Add request parameters as sources for the DOM-based XSS checker
+
 ### 3.1.5
 - Fix color bug that resulted in DOM XSS vulnerabilities not
   being reported on certain systems (Windows, macOS, iOS)

--- a/core/colors.py
+++ b/core/colors.py
@@ -6,7 +6,7 @@ colors = True  # Output should be colored
 machine = sys.platform  # Detecting the os of current system
 checkplatform = platform.platform() # Get current version of OS
 if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
-    colors = False  # Colors shouldn't be displayed in mac & windows
+    colors = False  # Colors shouldn't be displayed on mac & windows
 if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[2]) >= 10586:
     colors = True
     os.system('')   # Enables the ANSI

--- a/core/dom.py
+++ b/core/dom.py
@@ -1,7 +1,9 @@
 import re
 
-from core.colors import red, end, yellow
+from core.colors import end, red, yellow
 
+if len(end) < 1:
+    end = red = yellow = '*'
 
 def dom(response):
     highlighted = []

--- a/core/updater.py
+++ b/core/updater.py
@@ -3,7 +3,7 @@ import re
 from requests import get
 
 from core.config import changes
-from core.colors import run, que, good, info, end, green
+from core.colors import que, info, end, green
 from core.log import setup_logger
 
 logger = setup_logger(__name__)

--- a/modes/crawl.py
+++ b/modes/crawl.py
@@ -2,7 +2,7 @@ import copy
 import re
 
 import core.config
-from core.colors import red, good, green, end
+from core.colors import green, end
 from core.config import xsschecker
 from core.filterChecker import filterChecker
 from core.generator import generator

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, quote, unquote
 
 from core.arjun import arjun
 from core.checker import checker
-from core.colors import good, bad, end, info, green, red, que
+from core.colors import end, green, que
 import core.config
 from core.config import xsschecker, minEfficiency
 from core.dom import dom

--- a/modes/scan.py
+++ b/modes/scan.py
@@ -32,19 +32,10 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, sk
     logger.debug('Scan target: {}'.format(target))
     response = requester(target, {}, headers, GET, delay, timeout).text
 
-    if not skipDOM:
-        logger.run('Checking for DOM vulnerabilities')
-        highlighted = dom(response)
-        if highlighted:
-            logger.good('Potentially vulnerable objects found')
-            logger.red_line(level='good')
-            for line in highlighted:
-                logger.no_format(line, level='good')
-            logger.red_line(level='good')
     host = urlparse(target).netloc  # Extracts host out of the url
     logger.debug('Host to scan: {}'.format(host))
     url = getUrl(target, GET)
-    logger.debug('Url to scan: {}'.format(url))
+    logger.debug('URL to scan: {}'.format(url))
     params = getParams(target, paramData, GET)
     logger.debug_json('Scan parameters:', params)
     if find:
@@ -58,6 +49,15 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, find, sk
         logger.error('WAF detected: %s%s%s' % (green, WAF, end))
     else:
         logger.good('WAF Status: %sOffline%s' % (green, end))
+    if not skipDOM:
+        logger.run('Checking for DOM vulnerabilities')
+        highlighted = dom(response, params)
+        if highlighted:
+            logger.good('Potentially vulnerable objects found')
+            logger.red_line(level='good')
+            for line in highlighted:
+                logger.no_format(line, level='good')
+            logger.red_line(level='good')
 
     for paramName in params.keys():
         paramsCopy = copy.deepcopy(params)


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
Add request parameters as sources for DOM-based XSS check

Currently, the DOM-based XSS checker doesn't consider request parameters
as an input source.
This change allows the DOM-based XSS checker to detect code injected via
request parameters.

#### Where has this been tested?
Python Version: 3.7.5
Operating System: macOS

#### Does this close any currently open issues? 
No

#### Does this add any new dependency?
No

#### Does this add any new command line switch/option?
No

#### Any other comments you would like to make?
https://github.com/s0md3v/XSStrike/pull/285 should be merged first, as this change relies on it.

#### Some Questions
- [X] I have documented my code.
- [X] I have tested my build before submitting the pull request.