### PR TITLE
fix dom.py allControlledVariables position

### DIFF
--- a/core/dom.py
+++ b/core/dom.py
@@ -12,12 +12,12 @@ def dom(response):
     for script in scripts:
         script = script.split('\n')
         num = 1
+        allControlledVariables = set()
         try:
             for newLine in script:
                 line = newLine
                 parts = line.split('var ')
                 controlledVariables = set()
-                allControlledVariables = set()
                 if len(parts) > 1:
                     for part in parts:
                         for controlledVariable in allControlledVariables:


### PR DESCRIPTION
if var allControlledVariables in the `loop of newline and init`, would lose the highlight info of other lines.  and the follow code would be meaningless.
``` python
if len(parts) > 1:
                    for part in parts:
                        for controlledVariable in allControlledVariables:
                            if controlledVariable in part:
                                controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\$'))
```