### PR TITLE
Issue# 303. Added validation to the return code of the os.system call…

### DIFF
--- a/xsstrike.py
+++ b/xsstrike.py
@@ -17,7 +17,10 @@ try:
     except ImportError:
         import os
         print ('%s fuzzywuzzy isn\'t installed, installing now.' % info)
-        os.system('pip3 install fuzzywuzzy')
+        ret_code = os.system('pip3 install fuzzywuzzy')
+        if(ret_code != 0):
+            print('%s fuzzywuzzy installation failed.' % bad)
+            quit()
         print ('%s fuzzywuzzy has been installed, restart XSStrike.' % info)
         quit()
 except ImportError:  # throws error in python2


### PR DESCRIPTION

#### What does it implement/fix? Explain your changes.
Added validation to the return code of the os.system call to check if the fuzzywuzzy installation is success, so that the appropriate message can be printed based on the return code.
If return code is 0, success message is printed as the command succeeded. Else, failure message is printed.
#### Where has this been tested?
Python Version: 3.5.2\
Operating System: Ubuntu Xenial 16.04

#### Does this close any currently open issues? 
https://github.com/s0md3v/XSStrike/issues/303
#### Does this add any new dependency?
No
#### Does this add any new command line switch/option?
No

#### Any other comments you would like to make?
No
#### Some Questions
- [N/A] I have documented my code.
- [Y] I have tested my build before submitting the pull request.
