### PR TITLE
Support multiple blind xss payloads

### DIFF
--- a/modes/crawl.py
+++ b/modes/crawl.py
@@ -58,6 +58,12 @@ def crawl(scheme, host, main_url, form, blindXSS, blindPayload, headers, delay, 
                                     except IndexError:
                                         pass
                             if blindXSS and blindPayload:
-                                paramsCopy[paramName] = blindPayload
-                                requester(url, paramsCopy, headers,
-                                          GET, delay, timeout)
+                                if type(blindPayload) is tuple:
+                                    for x in blindPayload:
+                                        paramsCopy[paramName] = x
+                                        requester(url, paramsCopy, headers,
+                                                  GET, delay, timeout)
+                                else:
+                                    paramsCopy[paramName] = blindPayload
+                                    requester(url, paramsCopy, headers,
+                                              GET, delay, timeout)


### PR DESCRIPTION
Currently only a single payload is supported. After this change, users can configure a single value, or a tuple with multiple values, in the configuration file.

#### What does it implement/fix? Explain your changes.

#### Where has this been tested?
Python Version:\
Operating System:

#### Does this close any currently open issues? 

#### Does this add any new dependency?

#### Does this add any new command line switch/option?
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->

#### Any other comments you would like to make?

#### Some Questions
- [ ] I have documented my code.
- [ ] I have tested my build before submitting the pull request.
