### PR TITLE
Request timeout fixes with error trace printing to stdout.

### DIFF
--- a/core/checker.py
+++ b/core/checker.py
@@ -13,33 +13,36 @@ def checker(url, params, headers, GET, delay, payload, positions, timeout, encod
     if encoding:
         checkString = encoding(unquote(checkString))
     response = requester(url, replaceValue(
-        params, xsschecker, checkString, copy.deepcopy), headers, GET, delay, timeout).text.lower()
-    reflectedPositions = []
-    for match in re.finditer('st4r7s', response):
-        reflectedPositions.append(match.start())
-    filledPositions = fillHoles(positions, reflectedPositions)
-    #  Itretating over the reflections
-    num = 0
+        params, xsschecker, checkString, copy.deepcopy), headers, GET, delay, timeout)
+
     efficiencies = []
-    for position in filledPositions:
-        allEfficiencies = []
-        try:
-            reflected = response[reflectedPositions[num]
-                :reflectedPositions[num]+len(checkString)]
-            efficiency = fuzz.partial_ratio(reflected, checkString.lower())
-            allEfficiencies.append(efficiency)
-        except IndexError:
-            pass
-        if position:
-            reflected = response[position:position+len(checkString)]
-            if encoding:
-                checkString = encoding(checkString.lower())
-            efficiency = fuzz.partial_ratio(reflected, checkString)
-            if reflected[:-2] == ('\\%s' % checkString.replace('st4r7s', '').replace('3nd', '')):
-                efficiency = 90
-            allEfficiencies.append(efficiency)
-            efficiencies.append(max(allEfficiencies))
-        else:
-            efficiencies.append(0)
-        num += 1
+    if response:
+        response = response.text.lower()
+        reflectedPositions = []
+        for match in re.finditer('st4r7s', response):
+            reflectedPositions.append(match.start())
+        filledPositions = fillHoles(positions, reflectedPositions)
+        #  Itretating over the reflections
+        num = 0
+        for position in filledPositions:
+            allEfficiencies = []
+            try:
+                reflected = response[reflectedPositions[num]
+                    :reflectedPositions[num]+len(checkString)]
+                efficiency = fuzz.partial_ratio(reflected, checkString.lower())
+                allEfficiencies.append(efficiency)
+            except IndexError:
+                pass
+            if position:
+                reflected = response[position:position+len(checkString)]
+                if encoding:
+                    checkString = encoding(checkString.lower())
+                efficiency = fuzz.partial_ratio(reflected, checkString)
+                if reflected[:-2] == ('\\%s' % checkString.replace('st4r7s', '').replace('3nd', '')):
+                    efficiency = 90
+                allEfficiencies.append(efficiency)
+                efficiencies.append(max(allEfficiencies))
+            else:
+                efficiencies.append(0)
+            num += 1
     return list(filter(None, efficiencies))

--- a/core/requester.py
+++ b/core/requester.py
@@ -2,6 +2,10 @@ import random
 import requests
 import time
 from urllib3.exceptions import ProtocolError
+
+from urllib.error import HTTPError, URLError
+import socket
+
 import warnings
 
 import core.config
@@ -47,3 +51,11 @@ def requester(url, data, headers, GET, delay, timeout):
         logger.warning('WAF is dropping suspicious requests.')
         logger.warning('Scanning will continue after 10 minutes.')
         time.sleep(600)
+    except (HTTPError, URLError) as e:
+        if isinstance(e.reason, socket.timeout):
+                         print('Timeout')
+        else:
+            print("Error trace:\n", str(e))
+    except requests.exceptions.ConnectTimeout as e:
+        print("requests lib time out. Trace:\n", str(e))
+


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
Fixed timeout errors in `requester.py`, `checker.py`. 

#### Where has this been tested?
Python Version: 3.8
Operating System:
```bash
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
ID=kali
VERSION="2021.2"
VERSION_ID="2021.2"
VERSION_CODENAME="kali-rolling"
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
```

#### Does this close any currently open issues? 
I don't really know.

#### Does this add any new dependency?
Nope.

#### Does this add any new command line switch/option?
Nope.

