### PR TITLE
Moved (?s) to flags=re.S because it's a global flag

### DIFF
--- a/core/jsContexter.py
+++ b/core/jsContexter.py
@@ -8,7 +8,7 @@ def jsContexter(script):
     broken = script.split(xsschecker)
     pre = broken[0]
     #  remove everything that is between {..}, "..." or '...'
-    pre = re.sub(r'(?s)\{.*?\}|(?s)\(.*?\)|(?s)".*?"|(?s)\'.*?\'', '', pre)
+    pre = re.sub(r'\{.*?\}|\(.*?\)|".*?"|\'.*?\'', '', pre, flags=re.S)
     breaker = ''
     num = 0
     for char in pre:  # iterate over the remaining characters


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
Global flags aren't allowed not at the start of the regex

#### Where has this been tested?
Python Version: 3.11.3
Operating System: Arch Linux

#### Does this close any currently open issues? 
#372 #376 #377

#### Does this add any new dependency?
no

#### Does this add any new command line switch/option?
no

#### Any other comments you would like to make?
no

#### Some Questions
- [ ] I have documented my code.
- [x] I have tested my build before submitting the pull request.
