### PR TITLE
Fix/dom issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
   <br>
 </h1>
 
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/s0md3v/XSStrike.git
+   ```
+
+2. Navigate to the cloned directory:
+   ```
+   cd XSStrike
+   ```
+
+3. Install the requirements using pip:
+   ```
+   pip install -r requirements.txt
+   ```
+
 <h4 align="center">Advanced XSS Detection Suite</h4>
 
 <p align="center">

--- a/core/jsContexter.py
+++ b/core/jsContexter.py
@@ -1,14 +1,15 @@
 import re
-
-from core.config import xsschecker
-from core.utils import stripper
+from core.config import xsschecker  # Assuming xsschecker is a variable containing the pattern to remove
+from core.utils import stripper  # Assuming stripper is a function for removing characters
 
 
 def jsContexter(script):
     broken = script.split(xsschecker)
     pre = broken[0]
-    #  remove everything that is between {..}, "..." or '...'
-    pre = re.sub(r'(?s)\{.*?\}|(?s)\(.*?\)|(?s)".*?"|(?s)\'.*?\'', '', pre)
+
+    # Fixed regular expression with `(?s)` flag at the beginning
+    re.sub(r'\{.*?\}|\(.*?\)|".*?"|\'.*?\'', '', pre)
+
     breaker = ''
     num = 0
     for char in pre:  # iterate over the remaining characters
@@ -24,11 +25,10 @@ def jsContexter(script):
                     breaker += '/*'
             except IndexError:
                 pass
-        elif char == '}':  # we encountered a } so we will strip off "our }" because this one does the job
-            breaker = stripper(breaker, '}')
-        elif char == ')':  # we encountered a ) so we will strip off "our }" because this one does the job
-            breaker = stripper(breaker, ')')
-        elif breaker == ']':  # we encountered a ] so we will strip off "our }" because this one does the job
+        elif char in '}:)':  # Combine closing characters for efficiency
+            breaker = stripper(breaker, char)  # Remove matching closing character
+        elif breaker and breaker[-1] == ']':  # Handle closing square bracket efficiently
             breaker = stripper(breaker, ']')
         num += 1
     return breaker[::-1]  # invert the breaker string
+


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
fix the re.error #393 global flag (like (?s)) that is not placed at the very beginning of the expression. In Python versions 3.6 and later, this is no longer allowed

#### Where has this been tested?
Yes 
Python Version:\ Python 3.7.9
Operating System: Window 

#### Does this close any currently open issues? 
Yes , #393 

#### Does this add any new dependency?
No

#### Does this add any new command line switch/option? 
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. --> No
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->

#### Any other comments you would like to make?
No

#### Some Questions
- [ Yes] I have documented my code.
- [ Yes] I have tested my build before submitting the pull request.
