### PR TITLE
Implement NO_COLOR for terminal output 

### DIFF
--- a/core/colors.py
+++ b/core/colors.py
@@ -5,11 +5,18 @@ import platform
 colors = True  # Output should be colored
 machine = sys.platform  # Detecting the os of current system
 checkplatform = platform.platform() # Get current version of OS
-if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
-    colors = False  # Colors shouldn't be displayed on mac & windows
-if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[2]) >= 10586:
-    colors = True
-    os.system('')   # Enables the ANSI
+
+# Check for NO_COLOR environment variable, see https://no-color.org
+if 'NO_COLOR' in os.environ:
+    colors = False
+
+else :
+    if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
+        colors = False  # Colors shouldn't be displayed on mac & windows
+    if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[2]) >= 10586:
+        colors = True
+        os.system('')   # Enables the ANSI
+
 if not colors:
     end = red = white = green = yellow = run = bad = good = info = que = ''
 else:

--- a/core/colors.py
+++ b/core/colors.py
@@ -7,7 +7,7 @@ machine = sys.platform  # Detecting the os of current system
 checkplatform = platform.platform() # Get current version of OS
 
 # Check for NO_COLOR environment variable, see https://no-color.org
-if 'NO_COLOR' in os.environ:
+if ('NO_COLOR' in os.environ) or ('--no-color' in sys.argv):
     colors = False
 
 else :

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -80,6 +80,8 @@ parser.add_argument('--file-log-level', help='File logging level', dest='file_lo
                     choices=core.log.log_config.keys(), default=None)
 parser.add_argument('--log-file', help='Name of the file to log', dest='log_file',
                     default=core.log.log_file)
+parser.add_argument('--no-color', help='disable colored output', dest='no_color', 
+                    action='store_true')
 args = parser.parse_args()
 
 # Pull all parameter values of dict from argparse namespace into local variables of name == key


### PR DESCRIPTION
See https://no-color.org

#### What does it implement/fix? Explain your changes.

#### Where has this been tested?
Python Version: python3.11
Operating System: Windows 11, Debian GNU/Linux 12 (bookworm) on Windows 10 x86_64 (WSL)

#### Does this close any currently open issues? 

no

#### Does this add any new dependency?

no

#### Does this add any new command line switch/option?
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->
yes : `--no-color` or use env variable `NO_COLOR="1"`

#### Any other comments you would like to make?

#### Some Questions
- [x] I have documented my code.
- [X] I have tested my build before submitting the pull request.
