### PR TITLE
Fix syntax for Python 3.12

### DIFF
--- a/core/dom.py
+++ b/core/dom.py
@@ -24,7 +24,7 @@ def dom(response):
                     for part in parts:
                         for controlledVariable in allControlledVariables:
                             if controlledVariable in part:
-                                controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\$'))
+                                controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\\$'))
                 pattern = re.finditer(sources, newLine)
                 for grp in pattern:
                     if grp:
@@ -33,7 +33,7 @@ def dom(response):
                             if len(parts) > 1:
                                for part in parts:
                                     if source in part:
-                                        controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\$'))
+                                        controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\\$'))
                             line = line.replace(source, yellow + source + end)
                 for controlledVariable in controlledVariables:
                     allControlledVariables.add(controlledVariable)


### PR DESCRIPTION
Backslash needs escaping now.  Otherwise one sees:

.../XSStrike/core/dom.py:27: SyntaxWarning: invalid escape sequence '\$'
  controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\$'))
.../XSStrike/core/dom.py:36: SyntaxWarning: invalid escape sequence '\$'
  controlledVariables.add(re.search(r'[a-zA-Z$_][a-zA-Z0-9$_]+', part).group().replace('$', '\$'))

#### What does it implement/fix? Explain your changes.
Fixes a syntax error/python error

#### Where has this been tested?
Python Version: 3.12
Operating System: Linux/Debian

#### Does this close any currently open issues? 
No
#### Does this add any new dependency?
No
#### Does this add any new command line switch/option?
No

#### Any other comments you would like to make?

#### Some Questions

- [ YES] I have tested my build before submitting the pull request.
