### PR TITLE
Add --stop-count option (without formatting)

### DIFF
--- a/modes/scan.py
+++ b/modes/scan.py
@@ -18,7 +18,7 @@ from core.log import setup_logger
 logger = setup_logger(__name__)
 
 
-def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip):
+def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip, stop_count):
     GET, POST = (False, True) if paramData else (True, False)
     # If the user hasn't supplied the root url with http(s), we will handle it
     if not target.startswith('http'):
@@ -87,6 +87,7 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip):
             continue
         logger.info('Payloads generated: %i' % total)
         progress = 0
+        payloads_displayed_count = 0
         for confidence, vects in vectors.items():
             for vect in vects:
                 if core.config.globalVariables['path']:
@@ -107,6 +108,9 @@ def scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip):
                     logger.good('Payload: %s' % loggerVector)
                     logger.info('Efficiency: %i' % bestEfficiency)
                     logger.info('Confidence: %i' % confidence)
+                    payloads_displayed_count += 1
+                    if stop_count and payloads_displayed_count >= stop_count:
+                        return
                     if not skip:
                         choice = input(
                             '%s Would you like to continue scanning? [y/N] ' % que).lower()

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -17,7 +17,7 @@ try:
     except ImportError:
         import os
         print ('%s fuzzywuzzy isn\'t installed, installing now.' % info)
-        ret_code = os.system('pip3 install fuzzywuzzy')
+        ret_code = os.system('pip3 install fuzzywuzzy --break-system-packages')
         if(ret_code != 0):
             print('%s fuzzywuzzy installation failed.' % bad)
             quit()

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -47,8 +47,8 @@ parser.add_argument('--update', help='update',
                     dest='update', action='store_true')
 parser.add_argument('--timeout', help='timeout',
                     dest='timeout', type=int, default=core.config.timeout)
-parser.add_argument('--proxy', help='use prox(y|ies)',
-                    dest='proxy', action='store_true')
+parser.add_argument("--proxy", help="use a proxy (e.g. http://127.0.0.1:8081)",
+                    dest="proxy", type=str)
 parser.add_argument('--crawl', help='crawl',
                     dest='recursive', action='store_true')
 parser.add_argument('--json', help='treat post data as json',
@@ -94,6 +94,7 @@ encode = args.encode
 fuzz = args.fuzz
 update = args.update
 timeout = args.timeout
+proxy = args.proxy
 proxy = args.proxy
 recursive = args.recursive
 args_file = args.args_file
@@ -157,7 +158,10 @@ if args_seeds:
 
 encoding = base64 if encode and encode == 'base64' else False
 
-if not proxy:
+if proxy:
+    core.config.proxies = {"http": proxy, "https": proxy}
+    logger.info(f"proxy modified: {core.config.proxies}")
+else:
     core.config.proxies = {}
 
 if update:  # if the user has supplied --update argument

--- a/xsstrike.py
+++ b/xsstrike.py
@@ -71,6 +71,8 @@ parser.add_argument('--skip', help='don\'t ask to continue',
                     dest='skip', action='store_true')
 parser.add_argument('--skip-dom', help='skip dom checking',
                     dest='skipDOM', action='store_true')
+parser.add_argument("--stop-count",help="stop after displaying n payloads",
+                    dest="stop_count",type=int,default=None)
 parser.add_argument('--blind', help='inject blind XSS payload while crawling',
                     dest='blindXSS', action='store_true')
 parser.add_argument('--console-log-level', help='Console logging level',
@@ -103,6 +105,7 @@ delay = args.delay
 skip = args.skip
 skipDOM = args.skipDOM
 blindXSS = args.blindXSS
+stop_count = args.stop_count
 core.log.console_log_level = args.console_log_level
 core.log.file_log_level = args.file_log_level
 core.log.log_file = args.log_file
@@ -171,7 +174,7 @@ elif not recursive and not args_seeds:
     if args_file:
         bruteforcer(target, paramData, payloadList, encoding, headers, delay, timeout)
     else:
-        scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip)
+        scan(target, paramData, encoding, headers, delay, timeout, skipDOM, skip, stop_count)
 else:
     if target:
         seedList.append(target)


### PR DESCRIPTION
#### What does it implement/fix? It add --stop-count which allows to put a number and cut the scan when the number of payloads are displayed

#### Where has this been tested?
Python Version:\ 3.10.12
Operating System: ubuntu

#### Does this close any currently open issues?  No

#### Does this add any new dependency? No

#### Does this add any new command line switch/option? Yes, 
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->

#### Any other comments you would like to make?

#### Some Questions
- [ ] I have documented my code. No
- [ ] I have tested my build before submitting the pull request. Yes
